### PR TITLE
Use php attributes to configure commands

### DIFF
--- a/src/Command/Configure/PhpstormCommand.php
+++ b/src/Command/Configure/PhpstormCommand.php
@@ -15,18 +15,18 @@ use App\ValueObject\EnvironmentEntity;
 use DOMDocument;
 use DOMElement;
 use DOMXPath;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Filesystem\Filesystem;
 
+#[AsCommand(
+    name: 'origami:configure:phpstorm',
+    description: 'Copies the PhpStorm configuration associated to the current environment'
+)]
 class PhpstormCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:configure:phpstorm';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Copies the PhpStorm configuration associated to the current environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Database $database,

--- a/src/Command/DataCommand.php
+++ b/src/Command/DataCommand.php
@@ -9,17 +9,17 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:data',
+    description: 'Shows real-time usage statistics of the running environment'
+)]
 class DataCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:data';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Shows real-time usage statistics of the running environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/Database/DetailsCommand.php
+++ b/src/Command/Database/DetailsCommand.php
@@ -9,17 +9,17 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Database;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:database:details',
+    description: 'Shows the database details of the running environment'
+)]
 class DetailsCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:database:details';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Shows the database details of the running environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Database $database,

--- a/src/Command/Database/DumpCommand.php
+++ b/src/Command/Database/DumpCommand.php
@@ -13,18 +13,18 @@ use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Middleware\Database;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:database:dump',
+    description: 'Generates a database dump of the running environment'
+)]
 class DumpCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:database:dump';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Generates a database dump of the running environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Database $database,

--- a/src/Command/Database/ResetCommand.php
+++ b/src/Command/Database/ResetCommand.php
@@ -10,17 +10,17 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:database:reset',
+    description: 'Recreates the database volume of the running environment'
+)]
 class ResetCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:database:reset';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Recreates the database volume of the running environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/Database/RestoreCommand.php
+++ b/src/Command/Database/RestoreCommand.php
@@ -13,18 +13,18 @@ use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Middleware\Database;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:database:restore',
+    description: 'Restores a database dump of the running environment'
+)]
 class RestoreCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:database:restore';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Restores a database dump of the running environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Database $database,

--- a/src/Command/DebugCommand.php
+++ b/src/Command/DebugCommand.php
@@ -13,17 +13,17 @@ use App\Service\Middleware\Binary\Mkcert;
 use App\Service\Middleware\Binary\Mutagen;
 use App\Service\Wrapper\OrigamiStyle;
 use App\ValueObject\EnvironmentEntity;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:debug',
+    description: 'Shows system information and the configuration of the current environment'
+)]
 class DebugCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:debug';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Shows system information and the configuration of the current environment';
-
     public function __construct(
         private Docker $docker,
         private Mutagen $mutagen,

--- a/src/Command/DefaultCommand.php
+++ b/src/Command/DefaultCommand.php
@@ -6,25 +6,19 @@ namespace App\Command;
 
 use Exception;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:default',
+    description: 'Wrapper of the default "list" command',
+    hidden: true
+)]
 class DefaultCommand extends Command
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:default';
-
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure(): void
-    {
-        $this->setDescription('Wrapper of the default "list" command');
-        $this->setHidden(true);
-    }
-
     /**
      * {@inheritdoc}
      *

--- a/src/Command/InstallCommand.php
+++ b/src/Command/InstallCommand.php
@@ -10,18 +10,18 @@ use App\Service\Setup\ConfigurationFiles;
 use App\Service\Setup\EnvironmentBuilder;
 use App\Service\Wrapper\OrigamiStyle;
 use App\ValueObject\EnvironmentEntity;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[AsCommand(
+    name: 'origami:install',
+    description: 'Installs a local Docker environment for the project in the current directory'
+)]
 class InstallCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:install';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Installs a local Docker environment for the project in the current directory';
-
     public function __construct(
         private EnvironmentBuilder $builder,
         private ConfigurationFiles $configuration,

--- a/src/Command/LogsCommand.php
+++ b/src/Command/LogsCommand.php
@@ -8,19 +8,19 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:logs',
+    description: 'Shows the logs generated in real-time by the running environment'
+)]
 class LogsCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:logs';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Shows the logs generated in real-time by the running environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/PhpCommand.php
+++ b/src/Command/PhpCommand.php
@@ -9,19 +9,19 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:php',
+    description: 'Opens a terminal on the "php" service to interact with it'
+)]
 class PhpCommand extends AbstractBaseCommand
 {
     private const COMMAND_SERVICE_NAME = 'php';
     private const COMMAND_USERNAME = 'www-data:www-data';
-
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:php';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Opens a terminal on the "php" service to interact with it';
 
     public function __construct(
         private ApplicationContext $applicationContext,

--- a/src/Command/PrepareCommand.php
+++ b/src/Command/PrepareCommand.php
@@ -9,18 +9,18 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:prepare',
+    description: 'Prepares Docker images (i.e. pull and build) of a previously installed environment'
+)]
 class PrepareCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:prepare';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Prepares Docker images (i.e. pull and build) of a previously installed environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/PsCommand.php
+++ b/src/Command/PsCommand.php
@@ -9,17 +9,17 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:ps',
+    description: 'Shows the status of the running environment services'
+)]
 class PsCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:ps';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Shows the status of the running environment services';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/RegistryCommand.php
+++ b/src/Command/RegistryCommand.php
@@ -6,18 +6,18 @@ namespace App\Command;
 
 use App\Service\ApplicationData;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:registry',
+    description: 'Shows the list and status of all previously installed environments'
+)]
 class RegistryCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:registry';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Shows the list and status of all previously installed environments';
-
     public function __construct(
         private ApplicationData $applicationData,
         string $name = null

--- a/src/Command/RestartCommand.php
+++ b/src/Command/RestartCommand.php
@@ -11,18 +11,18 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[AsCommand(
+    name: 'origami:restart',
+    description: 'Restarts an environment previously started'
+)]
 class RestartCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:restart';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Restarts an environment previously started';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/RootCommand.php
+++ b/src/Command/RootCommand.php
@@ -9,19 +9,19 @@ use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
 use App\ValueObject\EnvironmentEntity;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\HttpFoundation\Request;
 
+#[AsCommand(
+    name: 'origami:root',
+    description: 'Shows instructions for configuring your terminal to manually use Docker commands'
+)]
 class RootCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:root';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Shows instructions for configuring your terminal to manually use Docker commands';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/StartCommand.php
+++ b/src/Command/StartCommand.php
@@ -11,19 +11,19 @@ use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
 use App\Service\Wrapper\ProcessProxy;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[AsCommand(
+    name: 'origami:start',
+    description: 'Starts an environment previously installed'
+)]
 class StartCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:start';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Starts an environment previously installed';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private ProcessProxy $processProxy,

--- a/src/Command/StopCommand.php
+++ b/src/Command/StopCommand.php
@@ -10,18 +10,18 @@ use App\Exception\OrigamiExceptionInterface;
 use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[AsCommand(
+    name: 'origami:stop',
+    description: 'Stops an environment previously started'
+)]
 class StopCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:stop';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Stops an environment previously started';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/UninstallCommand.php
+++ b/src/Command/UninstallCommand.php
@@ -11,19 +11,19 @@ use App\Service\ApplicationContext;
 use App\Service\Middleware\Binary\Docker;
 use App\Service\Setup\ConfigurationFiles;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
+#[AsCommand(
+    name: 'origami:uninstall',
+    description: 'Uninstalls an environment by deleting all Docker data and associated configuration'
+)]
 class UninstallCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:uninstall';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Uninstalls an environment by deleting all Docker data and associated configuration';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private Docker $docker,

--- a/src/Command/UpdateCommand.php
+++ b/src/Command/UpdateCommand.php
@@ -10,18 +10,18 @@ use App\Service\ApplicationContext;
 use App\Service\Setup\ConfigurationFiles;
 use App\Service\Setup\EnvironmentBuilder;
 use App\Service\Wrapper\OrigamiStyle;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+#[AsCommand(
+    name: 'origami:update',
+    description: 'Updates the configuration of a previously installed environment'
+)]
 class UpdateCommand extends AbstractBaseCommand
 {
-    /** {@inheritdoc} */
-    protected static $defaultName = 'origami:update';
-    /** {@inheritdoc} */
-    protected static $defaultDescription = 'Updates the configuration of a previously installed environment';
-
     public function __construct(
         private ApplicationContext $applicationContext,
         private EnvironmentBuilder $builder,


### PR DESCRIPTION
As a side note, `origami:database:details` command is missing on the [available commands wiki page](https://github.com/origamiphp/source/wiki/Available-Commands).