### PR TITLE
Move config file to config folder

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
         "ergebnis/environment-variables": "^1.0",
         "symfony/console": "6.0.*",
         "symfony/dotenv": "6.0.*",
+        "symfony/filesystem": "6.0.*",
         "symfony/flex": "^2.0.1",
         "symfony/framework-bundle": "6.0.*",
         "symfony/http-client": "6.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "739b2c3573d4f61474146ef937fad034",
+    "content-hash": "4c0d46edb68fa54c3d3fde42f5e56a5d",
     "packages": [
         {
             "name": "composer/semver",
@@ -1151,16 +1151,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.0.0",
+            "version": "v6.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "52b3c9cce673b014915445a432339f282e002ce6"
+                "reference": "6646c13f787057d64701a3a0235cf9567c6ccbbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/52b3c9cce673b014915445a432339f282e002ce6",
-                "reference": "52b3c9cce673b014915445a432339f282e002ce6",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6646c13f787057d64701a3a0235cf9567c6ccbbd",
+                "reference": "6646c13f787057d64701a3a0235cf9567c6ccbbd",
                 "shasum": ""
             },
             "require": {
@@ -1194,7 +1194,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.0.0"
+                "source": "https://github.com/symfony/filesystem/tree/v6.0.5"
             },
             "funding": [
                 {
@@ -1210,7 +1210,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-10-29T07:35:21+00:00"
+            "time": "2022-02-28T07:42:30+00:00"
         },
         {
             "name": "symfony/finder",


### PR DESCRIPTION
I propose to move the configuration file to the `~/.config` folder. This one has a lot of config files for many programs, it has become "common" for several years.

Also this will make it less likely that users will accidentally delete the file by wonder what is it.

Since the file is located in a dedicated "origami" folder, I also renamed the file "applications" to be more precise on what it contains.